### PR TITLE
Refactor/filter correction and prob

### DIFF
--- a/event_labelling/PR/helpers_pr.py
+++ b/event_labelling/PR/helpers_pr.py
@@ -1,5 +1,4 @@
 import os
-import re
 import pandas as pd
 from src.utils.botFilter import filter_bots_from_multiple_columns
 
@@ -40,68 +39,3 @@ def drop_bots_in_author_like_columns(df: pd.DataFrame, df_label: str) -> pd.Data
         inplace=False,
         verbose=True,
     )
-    
-
-LOG_PATTERN = re.compile(r"(?i)(?:\blogs?\b|weeklylogs?\b|teamlogs?\b|personallogs?\b)")
-
-def find_log_pr_ids(df: pd.DataFrame, df_label: str) -> set[str]:
-    """
-    Return the set of pr_id values (as strings) for which ANY row
-    contains the log pattern in ANY non-pr_id column.
-    """
-    if df.empty:
-        print(f"[INFO] {df_label}: empty df, no log PRs.")
-        return set()
-
-    if "pr_id" not in df.columns:
-        print(f"[WARN] {df_label}: no pr_id column, cannot build global log-pr set from this df.")
-        return set()
-
-    cols_to_check = [c for c in df.columns if c != "pr_id"]
-    if not cols_to_check:
-        print(f"[INFO] {df_label}: only pr_id column present, no log PRs.")
-        return set()
-
-    str_df = df[cols_to_check].astype(str)
-    col_matches = str_df.apply(lambda col: col.str.contains(LOG_PATTERN, na=False), axis=0)
-    row_has_log = col_matches.any(axis=1)
-
-    bad_pr_ids = (
-        df.loc[row_has_log, "pr_id"]
-          .dropna()
-          .astype(str)
-          .unique()
-          .tolist()
-    )
-
-    out = set(bad_pr_ids)
-    print(f"[STEP -1B DETECT] {df_label}: detected {len(out)} log PR_ids.")
-    return out
-
-
-def drop_pr_ids(df: pd.DataFrame, pr_ids_to_drop: set[str], df_label: str) -> pd.DataFrame:
-    """
-    Drop ALL rows whose pr_id is in pr_ids_to_drop.
-    """
-    if df.empty or not pr_ids_to_drop:
-        print(f"[STEP -1B APPLY] {df_label}: nothing to drop.")
-        return df
-
-    if "pr_id" not in df.columns:
-        print(f"[WARN] {df_label}: no pr_id column, cannot apply pr_id drop.")
-        return df
-
-    before_rows = len(df)
-    before_prs = df["pr_id"].nunique(dropna=True)
-
-    mask_keep = ~df["pr_id"].astype(str).isin(pr_ids_to_drop)
-    filtered = df[mask_keep].copy()
-
-    after_rows = len(filtered)
-    after_prs = filtered["pr_id"].nunique(dropna=True)
-
-    print(
-        f"[STEP -1B APPLY] {df_label}: dropped {before_rows - after_rows} rows "
-        f"({before_rows}->{after_rows}), PRs {before_prs}->{after_prs}."
-    )
-    return filtered

--- a/event_labelling/PR/prep_data.py
+++ b/event_labelling/PR/prep_data.py
@@ -8,9 +8,10 @@ from src.utils.enrich_columns import add_order_of_review
 # helper imports
 from event_labelling.PR.helpers_pr import (
     drop_bots_in_author_like_columns,
-    find_log_pr_ids,
-    drop_pr_ids,
 )
+from src.utils.logFilter import (
+    find_log_pr_ids,
+    drop_pr_ids,)
 
 
 # ---------------------------------------------------------------------

--- a/process_model/graphing.py
+++ b/process_model/graphing.py
@@ -177,8 +177,6 @@ def build_markov_graph(user_label, edges_df, event_freq, output_path, title_suff
 
     for u, v, data in G.edges(data=True):
         p = data.get("prob", 0.0)
-        if p < 0.01:
-            continue  # skip very weak transitions
         color = "#0D47A1" if p > 0.4 else "#1565C0" if p > 0.2 else "#64B5F6"
         dot.edge(str(u), str(v), label=f"{p:.2f}", color=color, penwidth=str(1.2 + p * 5))
 

--- a/src/utils/logFilter.py
+++ b/src/utils/logFilter.py
@@ -1,0 +1,66 @@
+import re
+import pandas as pd
+
+LOG_PATTERN = re.compile(r"(?i)(?:\blogs?\b|weeklylogs?\b|teamlogs?\b|personallogs?\b)")
+
+def find_log_pr_ids(df: pd.DataFrame, df_label: str) -> set[str]:
+    """
+    Return the set of pr_id values (as strings) for which ANY row
+    contains the log pattern in ANY non-pr_id column.
+    """
+    if df.empty:
+        print(f"[INFO] {df_label}: empty df, no log PRs.")
+        return set()
+
+    if "pr_id" not in df.columns:
+        print(f"[WARN] {df_label}: no pr_id column, cannot build global log-pr set from this df.")
+        return set()
+
+    cols_to_check = [c for c in df.columns if c != "pr_id"]
+    if not cols_to_check:
+        print(f"[INFO] {df_label}: only pr_id column present, no log PRs.")
+        return set()
+
+    str_df = df[cols_to_check].astype(str)
+    col_matches = str_df.apply(lambda col: col.str.contains(LOG_PATTERN, na=False), axis=0)
+    row_has_log = col_matches.any(axis=1)
+
+    bad_pr_ids = (
+        df.loc[row_has_log, "pr_id"]
+          .dropna()
+          .astype(str)
+          .unique()
+          .tolist()
+    )
+
+    out = set(bad_pr_ids)
+    print(f"[STEP -1B DETECT] {df_label}: detected {len(out)} log PR_ids.")
+    return out
+
+
+def drop_pr_ids(df: pd.DataFrame, pr_ids_to_drop: set[str], df_label: str) -> pd.DataFrame:
+    """
+    Drop ALL rows whose pr_id is in pr_ids_to_drop.
+    """
+    if df.empty or not pr_ids_to_drop:
+        print(f"[STEP -1B APPLY] {df_label}: nothing to drop.")
+        return df
+
+    if "pr_id" not in df.columns:
+        print(f"[WARN] {df_label}: no pr_id column, cannot apply pr_id drop.")
+        return df
+
+    before_rows = len(df)
+    before_prs = df["pr_id"].nunique(dropna=True)
+
+    mask_keep = ~df["pr_id"].astype(str).isin(pr_ids_to_drop)
+    filtered = df[mask_keep].copy()
+
+    after_rows = len(filtered)
+    after_prs = filtered["pr_id"].nunique(dropna=True)
+
+    print(
+        f"[STEP -1B APPLY] {df_label}: dropped {before_rows - after_rows} rows "
+        f"({before_rows}->{after_rows}), PRs {before_prs}->{after_prs}."
+    )
+    return filtered


### PR DESCRIPTION
This PR works towards addressing issue #31 by removing the probability filter in `graphing.py`, and correcting the log filtering so that it is uniformly applied for all identified log PR IDs across all csv files (currently we only focus on one csv file at a time, which may have left log PR IDs undeleted in other csvs).

### Testing Instruction
Please implement the two new functions in src/utils/logFilter.py: `find_log_pr_ids()` and `drop_pr_ids()` in your data prep step during labelling.
- Re-label a team csv that previously had dangling nodes
- Run the full process model steps until graphing (skip zscore and clustering if you have less than 2 re-labelled teams)
- Check if there are still dangling nodes

NOTE: if there are still dangling nodes, note which event they are. Then go to the transition edge csv and search in both to and from (or from and to) for that event specifically, observe if anything is off (does that event not exist in the "from" column, or does that event not exist in the "to" column? dangling means that node only has one arrow so one of the directions is not pointed to)

### Application Instruction
Below is a sample of how to implement the log filtering functions:
```python
bad_pr_ids = set()
bad_pr_ids |= find_log_pr_ids(raw_prs_df, f"{team_name} PRs")
bad_pr_ids |= find_log_pr_ids(raw_commits_df, f"{team_name} Commits")
bad_pr_ids |= find_log_pr_ids(raw_reviews_df, f"{team_name} Reviews")

raw_prs_df = drop_pr_ids(raw_prs_df, bad_pr_ids, f"{team_name} PRs")
raw_commits_df = drop_pr_ids(raw_commits_df, bad_pr_ids, f"{team_name} Commits")
raw_reviews_df = drop_pr_ids(raw_reviews_df, bad_pr_ids, f"{team_name} Reviews")
```