### PR TITLE
Add MagicNumberCheck detector with unit and team-scale tests

### DIFF
--- a/scripts/enrich_full_files.py
+++ b/scripts/enrich_full_files.py
@@ -1,0 +1,221 @@
+import sys
+import traceback
+import csv
+from pathlib import Path
+from datetime import datetime
+from typing import Optional, Set
+
+# Fix Python path to find src module
+project_root = Path(__file__).parent.parent.resolve()
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+print(f"[DEBUG] Project root: {project_root}")
+print(f"[DEBUG] Python path: {sys.path[:3]}")
+
+# Import extraction functionality
+try:
+    from src.extractors.pull_request_extractor import PullRequestExtractor
+    print("[DEBUG] Successfully imported PullRequestExtractor")
+except ImportError as e:
+    print(f"[ERROR] Failed to import PullRequestExtractor: {e}")
+    sys.exit(1)
+
+def enrich_full_files_for_repo(
+    repo_owner: str,
+    repo_name: str,
+    output_base_dir: str = "./data",
+    allowed_ext: Optional[Set[str]] = None,
+) -> Path:
+    """Build a CSV of full file contents at each PR head commit for files changed in those PRs."""
+
+    exts = allowed_ext or {
+        ".py", ".java", ".js", ".ts", ".jsx", ".tsx", ".rb", ".go",
+        ".cpp", ".c", ".h", ".hpp", ".cs", ".kt", ".rs", ".php", ".swift", ".sh"
+    }
+    
+    # Create output directories
+    base_path = Path(output_base_dir).resolve()
+    csv_dir = base_path / "csv" / repo_name
+    csv_dir.mkdir(parents=True, exist_ok=True)
+
+    # Full Files at PR Head CSV
+    out_csv = csv_dir / f"{repo_name}_full_files_at_pr_head.csv"
+
+    print("=" * 80)
+    print(f"FULL-FILE ENRICHMENT: {repo_owner}/{repo_name}")
+    print("=" * 80)
+    print(f"Started: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"Output:  {out_csv}")
+    print("=" * 80)
+
+    # Initialize extractor
+    extractor = PullRequestExtractor(
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        need_auth=True,
+    )
+
+    # Extract pull requests
+    print("[INFO] Fetching pull requests...")
+    pull_requests = extractor.extract_all_pull_requests(state="all")
+    
+    # Pre-cache PR file lists to avoid redundant API calls
+    print("[INFO] Pre-caching PR file lists...")
+
+    file_changes_cache = {}
+    for pr in pull_requests:
+        pr_id = pr["number"]  # GitHub PR number
+        file_changes_cache[pr_id] = extractor.extract_pr_file_changes(pr_id)
+
+    print(f"[INFO] Cached file lists for {len(file_changes_cache)} PRs")
+
+    # Write the full-file CSV 
+    fieldnames = ["pr_id", "head_sha", "file_path", "status", "previous_filename", "content"]
+    rows = []
+    cache = {}  # (head_sha, file_path) -> content
+    
+    # Decide whether a changed file should be included in full-file enrichment
+    def should_include_file(path: str, status: str) -> bool:
+        if not path:
+            return False
+        if status == "removed":
+            return False
+        lower = path.lower()
+        return any(lower.endswith(ext) for ext in exts)
+    
+    # Resolve the head commit SHA for a pull request
+    def get_head_sha_for_pr(pr: dict) -> Optional[str]:
+        head_sha = (pr.get("head") or {}).get("sha")
+        if head_sha:
+            return head_sha
+        pr_id_local = pr.get("number")
+        if not pr_id_local:
+            return None
+        full = extractor.extract_pull_request_by_id(pr_id_local)
+        return (full.get("head") or {}).get("sha") if full else None
+    
+    # Extract the full contents of a file at a specific commit SHA with caching
+    def fetch_file_content_cached(head_sha: str, path: str) -> Optional[str]:
+        key = (head_sha, path)
+        if key in cache:
+            return cache[key]
+        content = extractor.extract_file_content_at_ref(path=path, ref=head_sha)
+        cache[key] = content
+        return content
+
+    print(f"[INFO] Fetching full file contents for {len(pull_requests)} PRs...")
+
+    for pr_idx, pr in enumerate(pull_requests, 1):
+        if pr_idx % max(1, len(pull_requests) // 10) == 0:
+            print(f"[INFO] Full-file progress: {pr_idx}/{len(pull_requests)} PRs")
+
+        pr_id = pr.get("number")
+        if pr_id is None:
+            continue
+
+        head_sha = get_head_sha_for_pr(pr)
+        if not head_sha:
+            continue
+
+        files = file_changes_cache.get(pr_id, [])
+        for f in files:
+            path = f.get("filename")
+            status = f.get("status")
+            previous_filename = f.get("previous_filename")
+
+            if not should_include_file(path, status):
+                continue
+
+            content = fetch_file_content_cached(head_sha, path)
+            if not content:
+                continue
+
+            rows.append({
+                "pr_id": pr_id,
+                "head_sha": head_sha,
+                "file_path": path,
+                "status": status,
+                "previous_filename": previous_filename,
+                "content": content,
+            })
+
+    with open(out_csv, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"[SUCCESS] Wrote {len(rows)} rows → {out_csv}")
+    return out_csv
+
+
+if __name__ == "__main__":
+
+    # ==================== CONFIGURATION ====================
+
+    REPO_OWNER = "COSC-499-W2023"
+    REPO_NAMES = [
+        "year-long-project-team-15"
+    ]
+
+    OUTPUT_DIR = "./data"
+
+    # (Optional)
+    ALLOWED_EXT = None  # Example: {".java"} or None for default multi-language set
+
+    # ==================== EXECUTION ====================
+
+    print("\n" + "=" * 80)
+    print("FULL-FILE ENRICHMENT (CONFIG MODE)")
+    print("=" * 80)
+    print(f"Working directory: {Path.cwd()}")
+    print(f"Script location: {Path(__file__).parent}")
+    print(f"Total repositories to process: {len(REPO_NAMES)}")
+    print("=" * 80)
+
+    all_outputs = []
+    failed_repos = []
+
+    try:
+        for idx, repo_name in enumerate(REPO_NAMES, 1):
+            print(f"\n[{idx}/{len(REPO_NAMES)}] Processing: {repo_name}")
+
+            try:
+                out_csv = enrich_full_files_for_repo(
+                    repo_owner=REPO_OWNER,
+                    repo_name=repo_name,
+                    output_base_dir=OUTPUT_DIR,
+                    allowed_ext=ALLOWED_EXT,
+                )
+                all_outputs.append(out_csv)
+
+            except Exception as e:
+                print(f"[ERROR] Failed to process {repo_name}: {e}")
+                failed_repos.append((repo_name, str(e)))
+                traceback.print_exc()
+
+        print("\n" + "=" * 80)
+        print("ENRICHMENT SUMMARY")
+        print("=" * 80)
+        print(f"Successful: {len(all_outputs)}")
+        print(f"Failed: {len(failed_repos)}")
+
+        if failed_repos:
+            print("\n❌ FAILED REPOSITORIES:")
+            for repo_name, err in failed_repos:
+                print(f"  - {repo_name}: {err}")
+            sys.exit(1)
+        else:
+            print("\n✅ ALL REPOSITORIES ENRICHED SUCCESSFULLY")
+
+        print("=" * 80)
+
+    except Exception as e:
+        print(f"\n[FATAL ERROR] {e}")
+        traceback.print_exc()
+        sys.exit(1)
+
+    print("\n" + "=" * 80)
+    print(f"✅ SUCCESS - Finished: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print("=" * 80)
+

--- a/src/extractors/pull_request_extractor.py
+++ b/src/extractors/pull_request_extractor.py
@@ -7,6 +7,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import requests
 from dotenv import load_dotenv
 
+# Eextracts full file contents
+import base64
+from urllib.parse import quote
+
 # Import handling with fallbacks for development
 try:
     from src.extractors.git_extractor import GitExtractor
@@ -846,6 +850,43 @@ class PullRequestExtractor(GitExtractor):
             Complete commit dictionary with file changes
         """
         return self.extract_commit_details(commit_sha)
+    
+    # ============================================================================
+    # FULL FILE CONTENT EXTRACTION
+    # ============================================================================
+
+    def extract_file_content_at_ref(self, path: str, ref: str) -> Optional[str]:
+        """
+        Extract full file content at a specific commit SHA.
+
+        Args:
+            path: Repository-relative file path
+            ref: Commit SHA (or other git reference)
+
+        Returns:
+         - File content as a UTF-8 string, or
+          - None (not a text file / too large / not accessible)
+        """
+        safe_path = quote(path)
+        url = f"https://api.github.com/repos/{self.repo_owner}/{self.repo_name}/contents/{safe_path}?ref={ref}"
+
+        response = self.make_request_with_backoff(url)
+        if not response:
+            return None
+
+        data = response.json() or {}
+        if data.get("type") != "file":
+            return None
+
+        # Some large files may not have inline content
+        if data.get("encoding") != "base64" or "content" not in data:
+            return None
+
+        try:
+            raw_bytes = base64.b64decode(data["content"])
+            return raw_bytes.decode("utf-8", errors="replace")
+        except Exception:
+            return None
 
 
 # ============================================================================

--- a/src/violations/__init__.py
+++ b/src/violations/__init__.py
@@ -1,0 +1,24 @@
+"""
+Violations module.
+
+This package contains implementations of code-quality violation detectors.
+Each detector is responsible for identifying one specific violation type
+(e.g., MagicNumberCheck) using a testable and language-agnostic strategy.
+
+Current violation detectors:
+- MagicNumberCheck
+"""
+
+from .magic_number_check import (
+    MagicNumberFinding,
+    MagicNumberConfig,
+    detect_magic_numbers_from_code,
+    count_magic_numbers_from_code,
+)
+
+__all__ = [
+    "MagicNumberFinding",
+    "MagicNumberConfig",
+    "detect_magic_numbers_from_code",
+    "count_magic_numbers_from_code",
+]

--- a/src/violations/magic_number_check.py
+++ b/src/violations/magic_number_check.py
@@ -1,0 +1,287 @@
+"""
+MagicNumberCheck (v1) — simple, testable detector based on lightweight parsing.
+
+Goal:
+- Implement core detection logic on synthetic code snippets
+- Support controlled unit tests (no repo I/O here)
+- Keep behavior configurable and easy to extend later (AST, multi-language, etc.)
+
+This module intentionally starts with a *heuristic* approach:
+- Find numeric literals in code lines
+- Ignore allowed numbers (e.g., 0, 1)
+- Ignore literals in constant declarations (e.g., static final)
+- Ignore literals in annotations (e.g., @Something(123)) if configured
+- Flag the rest as "magic numbers"
+
+Later versions can replace the parsing with language-specific AST tooling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Sequence, Set, Tuple
+import re
+
+# Data structures
+
+@dataclass(frozen=True)
+class MagicNumberFinding:
+    """Represents one detected magic number occurrence."""
+    literal: str                 # e.g. "24", "1.05", "1000"
+    line_no: int                 # 1-based line number
+    column: int                  # 0-based column index (best-effort)
+    line_text: str               # the full source line (for debugging/tests)
+    reason: str = "numeric literal used directly in code"
+
+
+@dataclass
+class MagicNumberConfig:
+    """
+    Configuration for MagicNumberCheck.
+
+    Notes:
+    - ignored_numbers: numbers that are allowed as literals (commonly {0, 1}).
+      Can extend later (e.g., JetBrains ignores many small ints by default).
+    - ignore_in_constant_declarations: ignore numeric literals on constant definition lines
+      (e.g., 'static final int X = 24;'). Tools differ on border cases.
+    - ignore_in_annotations: ignore numeric literals in annotation lines (e.g., '@Size(10)').
+    - treat_negative_as_literal: if True, "-1" is treated as a single literal; else "1" with unary '-'.
+    """
+    ignored_numbers: Set[str] = field(default_factory=lambda: {"0", "1"})
+    ignore_in_constant_declarations: bool = True
+    ignore_in_annotations: bool = True
+    treat_negative_as_literal: bool = True
+
+    # Optional future config knobs
+    ignore_in_hashcode_method: bool = False  # placeholder for later
+
+# Public API
+
+def detect_magic_numbers_from_code(code: str, config: Optional[MagicNumberConfig] = None) -> List[MagicNumberFinding]:
+    """
+    Detect magic numbers from a code snippet (string).
+
+    This function is designed for unit tests and synthetic examples.
+    It does not perform language-aware parsing; it uses robust heuristics.
+
+    Args:
+        code: Source code as a string (can be Java/Python/etc. for heuristics).
+        config: Optional MagicNumberConfig.
+
+    Returns:
+        List of MagicNumberFinding.
+    """
+    cfg = config or MagicNumberConfig()
+    findings: List[MagicNumberFinding] = []
+
+    for idx, line in enumerate(code.splitlines(), start=1):
+        stripped = line.strip()
+
+        # Skip empty lines quickly
+        if not stripped:
+            continue
+
+        # Optional: ignore annotation lines (Java-like)
+        if cfg.ignore_in_annotations and _is_annotation_line(stripped):
+            continue
+
+        # Optional: ignore constant declarations (Java-like)
+        if cfg.ignore_in_constant_declarations and _is_constant_declaration_line(stripped):
+            # NOTE: Border cases like "final int HOURS = 20 + 4;" are subjective.
+            continue
+
+        # Extract numeric literals from the line
+        literals = _extract_numeric_literals(line, treat_negative_as_literal=cfg.treat_negative_as_literal)
+
+        for literal, col in literals:
+            normalized = _normalize_literal(literal)
+
+            # Ignore configured allowed values
+            if normalized in cfg.ignored_numbers:
+                continue
+
+            # Ignore numeric tokens that are part of an identifier
+            # e.g., var1 or HTTP2. This is a rough check; can be improved later.
+            if _looks_like_identifier_embedded_number(line, col, literal):
+                continue
+
+            findings.append(
+                MagicNumberFinding(
+                    literal=literal,
+                    line_no=idx,
+                    column=col,
+                    line_text=line.rstrip("\n"),
+                    reason="numeric literal used directly outside named constant",
+                )
+            )
+
+    return findings
+
+
+def count_magic_numbers_from_code(code: str, config: Optional[MagicNumberConfig] = None) -> int:
+    """Convenience wrapper to return count only."""
+    return len(detect_magic_numbers_from_code(code, config=config))
+
+
+# Internal helpers (heuristics)
+
+# Regex for numeric literals:
+# - integers: 123, 0
+# - floats: 1.05, .5, 5.
+# - scientific: 1e10, 1.2E-3
+# Notes: can be extended later.
+_NUMERIC_LITERAL_RE = re.compile(
+    r"""
+    (?P<num>
+        (?:\d+\.\d*|\.\d+|\d+)        # int or float
+        (?:[eE][+-]?\d+)?             # optional exponent
+    )
+    """,
+    re.VERBOSE,
+)
+
+# Negative numeric literal handling:
+# Treat "-123" as a literal only when '-' appears as unary minus,
+# which is hard without parsing. For now, merge "-" with number
+# if immediately adjacent: "-42", "-1.0", "-.5"
+_NEGATIVE_NUMERIC_LITERAL_RE = re.compile(
+    r"""
+    (?P<num>
+        -
+        (?:\d+\.\d*|\.\d+|\d+)
+        (?:[eE][+-]?\d+)? 
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _extract_numeric_literals(line: str, treat_negative_as_literal: bool) -> List[Tuple[str, int]]:
+    """
+    Return list of (literal, column) occurrences for numeric literals in the line.
+    Column is 0-based and best-effort.
+
+    If treat_negative_as_literal is True, match negatives like "-1".
+    """
+    literals: List[Tuple[str, int]] = []
+
+    # 1) Extract negative literals first (to avoid capturing the "1" part separately)
+    consumed_spans: List[Tuple[int, int]] = []
+    if treat_negative_as_literal:
+        for m in _NEGATIVE_NUMERIC_LITERAL_RE.finditer(line):
+            lit = m.group("num")
+            start = m.start("num")
+            end = m.end("num")
+            literals.append((lit, start))
+            consumed_spans.append((start, end))
+
+    def _span_consumed(pos: int) -> bool:
+        for s, e in consumed_spans:
+            if s <= pos < e:
+                return True
+        return False
+
+    # 2) Extract non-negative literals, skipping overlaps with negative matches
+    for m in _NUMERIC_LITERAL_RE.finditer(line):
+        lit = m.group("num")
+        start = m.start("num")
+        if _span_consumed(start):
+            continue
+        literals.append((lit, start))
+
+    return literals
+
+
+def _normalize_literal(literal: str) -> str:
+    """
+    Normalize literal string to compare with ignored_numbers.
+    For now keep it simple: strip underscores and whitespace.
+    """
+    return literal.strip().replace("_", "")
+
+
+def _is_annotation_line(stripped_line: str) -> bool:
+    """Java-like heuristic: lines starting with '@' are annotations."""
+    return stripped_line.startswith("@")
+
+
+def _is_constant_declaration_line(stripped_line: str) -> bool:
+    """
+    Heuristic for constant declarations (Java-like):
+    - contains 'final' AND '=' on the same line
+    - common forms: 'static final int X = 24;' or 'final double TAX = 0.05;'
+    """
+    # Basic heuristic:
+    if "final" not in stripped_line:
+        return False
+    if "=" not in stripped_line:
+        return False
+
+    # Exclude cases that are obviously not declarations (very rough)
+    # e.g., 'finally' keyword in try/catch
+    if "finally" in stripped_line:
+        return False
+
+    return True
+
+
+def _looks_like_identifier_embedded_number(line: str, col: int, literal: str) -> bool:
+    """
+    Best-effort check: if the character immediately before/after the literal is
+    an identifier char (letter, digit, underscore), then it might be part of a name.
+    E.g., var1, HTTP2, x100.
+
+    This is not perfect, but prevents common false positives.
+    """
+    start = col
+    end = col + len(literal)
+
+    def is_ident_char(ch: str) -> bool:
+        return ch.isalnum() or ch == "_"
+
+    if start - 1 >= 0 and is_ident_char(line[start - 1]):
+        return True
+    if end < len(line) and is_ident_char(line[end]):
+        return True
+    return False
+
+def extract_code_from_patch_snippet(patch_snippet: str) -> str:
+    """
+    Convert a git diff 'patch snippet' into plain code lines.
+
+    Intentionally drop diff metadata lines like:
+      - @@ -a,b +c,d @@
+      - diff --git, index, ---/+++
+    And strip the leading diff prefix ("+", "-", " ") from code lines.
+
+    This makes Team-scale testing possible using file_changes.csv.patch_snippet,
+    without fetching full repo files.
+    """
+    out_lines: List[str] = []
+
+    for raw in patch_snippet.splitlines():
+        line = raw.rstrip("\n")
+
+        # Skip diff metadata / headers
+        if line.startswith("@@"):
+            continue
+        if line.startswith("diff --git"):
+            continue
+        if line.startswith("index "):
+            continue
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+
+        # Skip "\ No newline at end of file" marker
+        if line.startswith("\\ No newline"):
+            continue
+
+        # Strip leading diff markers for actual code lines
+        if line.startswith(("+", "-", " ")):
+            out_lines.append(line[1:])
+        else:
+            # If it's an unexpected line format, keep it as-is (best effort)
+            out_lines.append(line)
+
+    return "\n".join(out_lines)
+

--- a/test/test_magic_number_check.py
+++ b/test/test_magic_number_check.py
@@ -1,0 +1,117 @@
+import os
+import sys
+import pytest
+
+# Add parent directory to path to enable imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Import the functions to test
+from src.violations.magic_number_check import (
+    MagicNumberConfig,
+    detect_magic_numbers_from_code,
+    count_magic_numbers_from_code,
+)
+
+
+class TestMagicNumberCheckBasics:
+    """Test suite for basic MagicNumberCheck behavior"""
+
+    def test_flags_simple_integer_literal_in_expression(self):
+        """Test that a simple integer literal in an expression is flagged"""
+        code = "return 24 * days;"
+        findings = detect_magic_numbers_from_code(code)
+        assert len(findings) == 1
+        assert findings[0].literal == "24"
+        assert findings[0].line_no == 1
+
+    def test_flags_float_literal_in_expression(self):
+        """Test that a float literal in an expression is flagged"""
+        code = "price_after_tax = 1.05 * price"
+        findings = detect_magic_numbers_from_code(code)
+        assert len(findings) == 1
+        assert findings[0].literal == "1.05"
+
+    def test_ignores_trivial_numbers_by_default(self):
+        """Test that default ignored numbers (0 and 1) are not flagged"""
+        code = "\n".join([
+            "if (x == 0) { return 1; }",
+            "count = count + 1;",
+        ])
+        findings = detect_magic_numbers_from_code(code)
+        assert len(findings) == 0
+
+    def test_counts_findings_correctly(self):
+        """Test that count helper returns the same count as detection output"""
+        code = "\n".join([
+            "return 24 * days;",
+            "return 7 * weeks;",
+        ])
+        findings = detect_magic_numbers_from_code(code)
+        count = count_magic_numbers_from_code(code)
+        assert count == len(findings)
+        assert count == 2
+
+
+class TestMagicNumberCheckConstantHandling:
+    """Test suite for ignoring literals in constant declarations"""
+
+    def test_ignores_java_style_constant_declaration(self):
+        """Test that literals in Java-like constant declarations are ignored by default"""
+        code = "\n".join([
+            "static final int HOURS_PER_DAY = 24;",
+            "return HOURS_PER_DAY * days;",
+        ])
+        findings = detect_magic_numbers_from_code(code)
+        # The constant declaration line is ignored; there should be no findings
+        assert len(findings) == 0
+
+    def test_can_flag_literals_in_constant_declaration_when_configured(self):
+        """Test that literals in constant declarations can be flagged if configured"""
+        code = "static final int HOURS_PER_DAY = 24;"
+        cfg = MagicNumberConfig(ignore_in_constant_declarations=False)
+        findings = detect_magic_numbers_from_code(code, config=cfg)
+        assert len(findings) == 1
+        assert findings[0].literal == "24"
+
+
+class TestMagicNumberCheckAnnotationHandling:
+    """Test suite for ignoring literals in annotations"""
+
+    def test_ignores_annotation_line_by_default(self):
+        """Test that annotation lines are ignored by default"""
+        code = "\n".join([
+            "@Size(10)",
+            "String name = input;",
+        ])
+        findings = detect_magic_numbers_from_code(code)
+        assert len(findings) == 0
+
+    def test_can_flag_literals_in_annotations_when_configured(self):
+        """Test that annotation literals can be flagged if configured"""
+        code = "@Size(10)"
+        cfg = MagicNumberConfig(ignore_in_annotations=False)
+        findings = detect_magic_numbers_from_code(code, config=cfg)
+        assert len(findings) == 1
+        assert findings[0].literal == "10"
+
+
+class TestMagicNumberCheckNegativeNumbers:
+    """Test suite for handling negative numeric literals"""
+
+    def test_flags_negative_literal_by_default(self):
+        """Test that negative literals are detected as a single literal by default"""
+        code = "return -5;"
+        findings = detect_magic_numbers_from_code(code)
+        assert len(findings) == 1
+        assert findings[0].literal == "-5"
+
+    def test_can_ignore_negative_literal_if_added_to_ignored_numbers(self):
+        """Test that negative literals can be ignored if configured in ignored_numbers"""
+        code = "return -1;"
+        cfg = MagicNumberConfig(ignored_numbers={"0", "1", "-1"})
+        findings = detect_magic_numbers_from_code(code, config=cfg)
+        assert len(findings) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/test/test_magic_number_team15_patch_fixture.py
+++ b/test/test_magic_number_team15_patch_fixture.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import pytest
+
+# Keep existing sys.path approach for now (repo infra may not be standardized yet)
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from src.violations.magic_number_check import (
+    MagicNumberConfig,
+    detect_magic_numbers_from_code,
+    extract_code_from_patch_snippet,
+)
+
+# Real Team 15 patch_snippet fixture (JavaScript-heavy repo, but test goal is language-agnostic):
+# Ensure diff hunk header numbers like @@ -11,15 +11,17 @@ are not treated as code literals.
+TEAM15_PATCH_SNIPPET = """@@ -11,15 +11,17 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
+ import { fetchSpecificFriendRequest } from '../services/FriendService';
+ import ConfirmationDialog from '../components/ConfirmDialog';
+ import { fetchFriendDetails } from '../services/FriendService';
+-import AddFriend from './AddFriend';
++import useFriends from '../hooks/useFriends';
++import { useFriend } from '../context/FriendContext';
+
+-const ManageFriends = ({ onFriendDeleted }) => {
++const ManageFriends = () => {
++    const [friendsData, setFriendsData] = useFriends();
+     const [expanded, setExpanded] = useState(false);
+     const { currentUserId } = useCurrentUser();
+     const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+     const [pendingDeleteFriend, setPendingDeleteFriend] = useState({ id: null, name: "" });
+-
+-
++    const { selectedFriend, clearFriendContext } = useFriend();
+
+     const handleDeleteFriend = async (friendId) => {
+         try {
+             const friendDetails = await fetchFriendDetails([friendId]);
+@@ -56,10 +58,15 @@ const ManageFriends = ({ onFriendDeleted }) => {
+                   })
+                 ));
+           }
+-          AddFriend();
+-
++          const updatedFriendsData = friendsData.filter(friends => friends.id !== friendId);
++          setFriendsData(updatedFriendsData);
++          if(selectedFriend.id === friendId){
++            clearFriendContext();
++          }
++
+         console.log("Friend request(s) deleted for user ID:", friendId);
+-        onFriendDeleted(friendId);
++
+       } catch (error) {
+         console.error("Error deleting friend request:", error);
+       }
+@@ -72,7 +79,7 @@ return (
+         <Typography>My Friends</Typography>
+       </AccordionSummary>
+       <AccordionDetails>
+-        <FriendSearchAndList showDeleteButtons={true} onDelete={handleDeleteFriend} />
++        <FriendSearchAndList friendsData={friendsData} showDeleteButtons={true} onDelete={handleDeleteFriend} />
+       </AccordionDetails>
+     </Accordion>
+     <ConfirmationDialog
+"""
+
+
+def test_team15_patch_snippet_ignores_diff_hunk_header_numbers():
+    """
+    Team 15 scale test (real patch_snippet):
+    - We run the detector on a real GitHub diff hunk
+    - We must NOT flag numeric values in diff headers (e.g., @@ -11,15 +11,17 @@)
+    - This should hold regardless of the underlying programming language
+    """
+    code = extract_code_from_patch_snippet(TEAM15_PATCH_SNIPPET)
+
+    findings = detect_magic_numbers_from_code(
+        code,
+        config=MagicNumberConfig(
+            ignored_numbers={"0", "1"},
+            ignore_in_constant_declarations=False,
+            ignore_in_annotations=True,
+            treat_negative_as_literal=True,
+        ),
+    )
+
+    # This particular snippet has no actual numeric literals in the code body
+    # (only diff header numbers). Expect no findings.
+    assert findings == []
+
+
+def test_patch_pipeline_detects_real_literal_in_code_body_language_agnostic():
+    """
+    Same patch_snippet pipeline, but ensure it DOES detect numeric literals
+    when they appear in the actual code lines (not only in diff metadata).
+
+    This fixture is intentionally language-agnostic:
+    - "timeout_ms = 3000" looks like Python
+    - but even if interpreted as pseudo-code, the detector should still find "3000"
+    """
+    patch = (
+        "@@ -1,1 +1,3 @@\n"
+        "+timeout_ms = 3000\n"
+        "+print(timeout_ms)\n"
+    )
+
+    code = extract_code_from_patch_snippet(patch)
+
+    findings = detect_magic_numbers_from_code(
+        code,
+        config=MagicNumberConfig(
+            ignored_numbers={"0", "1"},
+            ignore_in_constant_declarations=False,
+            ignore_in_annotations=True,
+            treat_negative_as_literal=True,
+        ),
+    )
+
+    literals = [f.literal for f in findings]
+    assert "3000" in literals
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])
+

--- a/test/test_magic_number_team_scaled_csv.py
+++ b/test/test_magic_number_team_scaled_csv.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import csv
+import re
+import pytest
+
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from src.violations.magic_number_check import (
+    MagicNumberConfig,
+    detect_magic_numbers_from_code,
+    extract_code_from_patch_snippet,
+)
+
+DEFAULT_TEAM15_CSV = os.path.join(
+    project_root,
+    "data",
+    "csv",
+    "year-long-project-team-15",
+    "year-long-project-team-15_commit_file_changes.csv",
+)
+
+ENV_PATH = "MAGIC_NUMBER_PATCH_CSV"
+
+# Matches diff hunk headers like: @@ -8,13 +8,36 @@
+_HUNK_HEADER_LINE_RE = re.compile(r"^@@\s*-[0-9]+(?:,[0-9]+)?\s*\+[0-9]+(?:,[0-9]+)?\s*@@\s*$", re.MULTILINE)
+
+
+def _read_patch_snippets(csv_path: str):
+    """Yield (row_index, patch_snippet) for each row in the CSV that has a patch_snippet."""
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if "patch_snippet" not in (reader.fieldnames or []):
+            raise AssertionError(f"CSV is missing 'patch_snippet' column: {csv_path}")
+
+        for i, row in enumerate(reader, start=1):
+            patch = (row.get("patch_snippet") or "").strip()
+            # Skip empty patches (GitHub sometimes omits patch for large diffs / binaries)
+            if not patch:
+                continue
+            yield i, patch
+
+
+def _findings_from_patch(patch: str):
+    """Run detection on code extracted from a patch snippet."""
+    code = extract_code_from_patch_snippet(patch)
+    cfg = MagicNumberConfig(
+        ignored_numbers={"0", "1"},
+        ignore_in_constant_declarations=False,
+        ignore_in_annotations=True,
+        treat_negative_as_literal=True,
+    )
+    return code, detect_magic_numbers_from_code(code, config=cfg)
+
+
+def test_team_scaled_csv_smoke_and_no_hunk_header_lines_processed():
+    """
+    Team-scale test (Team 15):
+    - Iterate ALL patch_snippet rows from a CSV file
+    - Ensure the pipeline does not crash
+    - Ensure diff hunk header lines are removed by extract_code_from_patch_snippet()
+      so we never treat @@ -a,b +c,d @@ as code.
+
+    Run:
+      MAGIC_NUMBER_PATCH_CSV=data/csv/year-long-project-team-15/year-long-project-team-15_commit_file_changes.csv \
+      pytest -q test/test_magic_number_team_scaled_csv.py
+    """
+    csv_path = os.environ.get(ENV_PATH, DEFAULT_TEAM15_CSV)
+    assert os.path.exists(csv_path), f"CSV file not found: {csv_path}"
+
+    checked = 0
+
+    for row_idx, patch in _read_patch_snippets(csv_path):
+        checked += 1
+
+        # sanity: patch should have (optional) hunk headers, but extracted code should not
+        code, findings = _findings_from_patch(patch)
+
+        # Invariant A: extracted code should not contain any full hunk header line.
+        # Check line-by-line so strings containing '@@' (like '@@toPrimitive') won't fail.
+        for line in code.splitlines():
+            assert not _HUNK_HEADER_LINE_RE.match(line.strip()), (
+                f"Row {row_idx}: extract_code_from_patch_snippet leaked a hunk header line into code. "
+                f"Line={line!r}"
+            )
+
+        # Invariant B: even if the detector flags real numeric literals, it should never
+        # flag something *on a hunk header line*.
+        for f in findings:
+            assert not f.line_text.strip().startswith("@@"), (
+                f"Row {row_idx}: detector produced a finding on a hunk header line. "
+                f"Literal={f.literal}, line={f.line_text!r}"
+            )
+
+    assert checked > 0, f"No non-empty patch_snippet rows found in {csv_path}"
+
+


### PR DESCRIPTION
### Summary
Implements the first violation detector: **MagicNumberCheck**, designed to be testable and safe on real GitHub diff data.

### What’s included
- New detector: `src/violations/magic_number_check.py`
- Package init: `src/violations/__init__.py`
- Tests:
  - `test/test_magic_number_check.py` (controlled unit tests on synthetic snippets)
  - `test/test_magic_number_team15_patch_fixture.py` (single real Team 15 patch_snippet fixture)
  - `test/test_magic_number_team_scaled_csv.py` (iterates all Team 15 patch_snippet rows from CSV via `MAGIC_NUMBER_PATCH_CSV`)

### How to test
```bash
pytest -q test/test_magic_number_check.py
pytest -q test/test_magic_number_team15_patch_fixture.py
MAGIC_NUMBER_PATCH_CSV=data/csv/year-long-project-team-15/year-long-project-team-15_commit_file_changes.csv \
pytest -q test/test_magic_number_team_scaled_csv.py
```

**Notes**: 
- The team-scale test intentionally sweeps all patch_snippet rows to ensure diff hunk headers (`@@ -a,b +c,d @@`) are not treated as code.
- Documentation (`documentation/violations.md`) will be submitted in a separate PR as requested.