### PR TITLE
Refactor/matrix zscore output

### DIFF
--- a/process_model/clustering.py
+++ b/process_model/clustering.py
@@ -17,8 +17,6 @@ ROOT = os.path.abspath(os.path.join(CURRENT_DIR, "../"))
 # ============================================================
 # CONFIGURATION SWITCH - Choose which files to process
 # ============================================================
-# Set to "branching" or "pr_labels"
-# Can be set via environment variable: FILE_SOURCE=branching python ...
 script_path = Path(__file__).resolve()
 print(f"[DEBUG] Script location: {script_path}")
 
@@ -50,12 +48,22 @@ IN_FP = os.path.join(DATA_DIR, "team_transition_edges_avg_session_zscores.csv")
 OUT_FP = os.path.join(DATA_DIR, f"behavior_clusters_{CLUSTER_SUFFIX}.csv")
 
 MATRIX_OUT_FP = os.path.join(DATA_DIR, f"team_transition_matrix_{CLUSTER_SUFFIX}.csv")
-
 FILTERED_EDGES_OUT_FP = os.path.join(
     DATA_DIR, f"team_transition_edges_avg_session_zfiltered_{CLUSTER_SUFFIX}.csv"
 )
 
-Z_THRESHOLD = 1.645  # pick in clustering, not zscore script
+Z_THRESHOLD = 1.645  # chosen here (not buried inside filtering)
+
+
+def filter_edges_by_zscore(df: pd.DataFrame, cutoff: float) -> pd.DataFrame:
+    """
+    Returns only edges with |z_score| >= cutoff (both tails).
+    cutoff is an input parameter (not hardcoded inside this function).
+    """
+    if "z_score" not in df.columns:
+        raise ValueError("Expected 'z_score' column in input; zscore_calculation.py should generate it.")
+    return df[df["z_score"].abs() >= cutoff].copy()
+
 
 def build_team_matrix(df: pd.DataFrame, z_threshold: float):
     df = df.copy()
@@ -68,13 +76,8 @@ def build_team_matrix(df: pd.DataFrame, z_threshold: float):
                    key=lambda x: int(x) if x.isdigit() else 999999)
     X = np.zeros((len(teams), len(pairs)), dtype=float)
 
-    # apply threshold here
-    if "z_score" in df.columns:
-        df_filt = df[df["z_score"].abs() >= z_threshold].copy()
-
-
-    else:
-        raise ValueError("Expected 'z_score' column in input; zscore_calculation.py should generate it.")
+    # ✅ apply threshold via function call
+    df_filt = filter_edges_by_zscore(df, cutoff=z_threshold)
 
     for ti, team in enumerate(teams):
         g = df_filt[df_filt["team_number"].astype(str) == team]
@@ -106,44 +109,45 @@ def choose_best_k(X: np.ndarray, k_min=2, k_max=10):
 
     return best_k, best_score
 
+
 def main():
     if not os.path.exists(IN_FP):
         raise FileNotFoundError(
             f"Missing required input: {IN_FP}\n"
             f"Run zscore_calculation.py first with FOLDER_SOURCE='{FOLDER_SOURCE}'"
         )
-    
+
     print(f"[INFO] Loading data from: {IN_FP}")
     df = pd.read_csv(IN_FP, low_memory=False)
-    
+
     print("[INFO] Building team matrix...")
     teams, pairs, X, df_filt = build_team_matrix(df, z_threshold=Z_THRESHOLD)
 
     nonzero_mask = (X.sum(axis=1) > 0)
     kept_teams = [t for t, keep in zip(teams, nonzero_mask) if keep]
     X = X[nonzero_mask]
-    
+
     dropped = int((~nonzero_mask).sum())
     if dropped:
         print(f"[INFO] Dropped {dropped} teams with all-zero vectors at |z| ≥ {Z_THRESHOLD}")
-    
+
+    # export z-filtered edges for kept teams
     df_filt = df_filt.copy()
     df_filt["team_number"] = df_filt["team_number"].astype(str)
     df_filt_kept = df_filt[df_filt["team_number"].isin(set(map(str, kept_teams)))].copy()
-    
+
     cols_first = ["team_number", "from", "to", "count", "z_score"]
     remaining = [c for c in df_filt_kept.columns if c not in cols_first]
     df_filt_kept = df_filt_kept[cols_first + remaining]
     df_filt_kept.to_csv(FILTERED_EDGES_OUT_FP, index=False)
     print(f"[OK] Wrote z-filtered edges: {FILTERED_EDGES_OUT_FP}")
-        
-    # Column names become "from->to" so they're readable in CSV.
+
+    # export transition matrix
     col_names = [f"{a}->{b}" for (a, b) in pairs]
     matrix_df = pd.DataFrame(X, index=kept_teams, columns=col_names)
     matrix_df.index.name = "team_number"
     matrix_df.to_csv(MATRIX_OUT_FP)
     print(f"[OK] Wrote transition matrix: {MATRIX_OUT_FP}")
-
 
     if X.shape[0] < 2:
         out = pd.DataFrame({"team_number": kept_teams, "cluster_id": [0] * len(kept_teams)})
@@ -164,6 +168,7 @@ def main():
     })
     out.to_csv(OUT_FP, index=False)
     print(f"[OK] Wrote: {OUT_FP}")
+
 
 if __name__ == "__main__":
     main()

--- a/process_model/clustering.py
+++ b/process_model/clustering.py
@@ -52,7 +52,7 @@ FILTERED_EDGES_OUT_FP = os.path.join(
     DATA_DIR, f"team_transition_edges_avg_session_zfiltered_{CLUSTER_SUFFIX}.csv"
 )
 
-Z_THRESHOLD = 1.645  # chosen here (not buried inside filtering)
+Z_THRESHOLD = 1.645  # default is 1.645 for 90% confidence can adjust to 1.96 for 95% confidence
 
 
 def filter_edges_by_zscore(df: pd.DataFrame, cutoff: float) -> pd.DataFrame:

--- a/process_model/clustering.py
+++ b/process_model/clustering.py
@@ -64,7 +64,8 @@ def build_team_matrix(df: pd.DataFrame, z_threshold: float):
 
     # apply threshold here
     if "z_score" in df.columns:
-        df = df[df["z_score"] >= z_threshold].copy()
+        df = df[df["z_score"].abs() >= z_threshold].copy()
+
     else:
         raise ValueError("Expected 'z_score' column in input; zscore_calculation.py should generate it.")
 

--- a/process_model/clustering.py
+++ b/process_model/clustering.py
@@ -49,6 +49,12 @@ else:
 IN_FP = os.path.join(DATA_DIR, "team_transition_edges_avg_session_zscores.csv")
 OUT_FP = os.path.join(DATA_DIR, f"behavior_clusters_{CLUSTER_SUFFIX}.csv")
 
+MATRIX_OUT_FP = os.path.join(DATA_DIR, f"team_transition_matrix_{CLUSTER_SUFFIX}.csv")
+
+FILTERED_EDGES_OUT_FP = os.path.join(
+    DATA_DIR, f"team_transition_edges_avg_session_zfiltered_{CLUSTER_SUFFIX}.csv"
+)
+
 Z_THRESHOLD = 1.645  # pick in clustering, not zscore script
 
 def build_team_matrix(df: pd.DataFrame, z_threshold: float):
@@ -64,19 +70,20 @@ def build_team_matrix(df: pd.DataFrame, z_threshold: float):
 
     # apply threshold here
     if "z_score" in df.columns:
-        df = df[df["z_score"].abs() >= z_threshold].copy()
+        df_filt = df[df["z_score"].abs() >= z_threshold].copy()
+
 
     else:
         raise ValueError("Expected 'z_score' column in input; zscore_calculation.py should generate it.")
 
     for ti, team in enumerate(teams):
-        g = df[df["team_number"].astype(str) == team]
+        g = df_filt[df_filt["team_number"].astype(str) == team]
         for _, r in g.iterrows():
             idx = pair_to_idx.get((r["from"], r["to"]))
             if idx is not None:
                 X[ti, idx] = float(r["count"])
 
-    return teams, pairs, X
+    return teams, pairs, X, df_filt
 
 
 def choose_best_k(X: np.ndarray, k_min=2, k_max=10):
@@ -110,19 +117,36 @@ def main():
     df = pd.read_csv(IN_FP, low_memory=False)
     
     print("[INFO] Building team matrix...")
-    teams, pairs, X = build_team_matrix(df, z_threshold=Z_THRESHOLD)
+    teams, pairs, X, df_filt = build_team_matrix(df, z_threshold=Z_THRESHOLD)
 
     nonzero_mask = (X.sum(axis=1) > 0)
-    teams = [t for t, keep in zip(teams, nonzero_mask) if keep]
+    kept_teams = [t for t, keep in zip(teams, nonzero_mask) if keep]
     X = X[nonzero_mask]
     
     dropped = int((~nonzero_mask).sum())
     if dropped:
-        print(f"[INFO] Dropped {dropped} teams with all-zero vectors at z ≥ {Z_THRESHOLD}")
+        print(f"[INFO] Dropped {dropped} teams with all-zero vectors at |z| ≥ {Z_THRESHOLD}")
+    
+    df_filt = df_filt.copy()
+    df_filt["team_number"] = df_filt["team_number"].astype(str)
+    df_filt_kept = df_filt[df_filt["team_number"].isin(set(map(str, kept_teams)))].copy()
+    
+    cols_first = ["team_number", "from", "to", "count", "z_score"]
+    remaining = [c for c in df_filt_kept.columns if c not in cols_first]
+    df_filt_kept = df_filt_kept[cols_first + remaining]
+    df_filt_kept.to_csv(FILTERED_EDGES_OUT_FP, index=False)
+    print(f"[OK] Wrote z-filtered edges: {FILTERED_EDGES_OUT_FP}")
+        
+    # Column names become "from->to" so they're readable in CSV.
+    col_names = [f"{a}->{b}" for (a, b) in pairs]
+    matrix_df = pd.DataFrame(X, index=kept_teams, columns=col_names)
+    matrix_df.index.name = "team_number"
+    matrix_df.to_csv(MATRIX_OUT_FP)
+    print(f"[OK] Wrote transition matrix: {MATRIX_OUT_FP}")
 
 
     if X.shape[0] < 2:
-        out = pd.DataFrame({"team_number": teams, "cluster_id": [0] * len(teams)})
+        out = pd.DataFrame({"team_number": kept_teams, "cluster_id": [0] * len(kept_teams)})
         out.to_csv(OUT_FP, index=False)
         print(f"[OK] Wrote: {OUT_FP} (not enough teams to cluster)")
         return
@@ -133,7 +157,7 @@ def main():
     clusters = km.fit_predict(X)
 
     out = pd.DataFrame({
-        "team_number": teams,
+        "team_number": kept_teams,
         "cluster_id": clusters,
         "k_used": best_k,
         "silhouette": best_sil if best_sil is not None else np.nan,

--- a/process_model/graphing.py
+++ b/process_model/graphing.py
@@ -55,12 +55,38 @@ IN_AVG_FP = os.path.join(PR_OUT_DIR, "team_transition_edges_avg_session.csv")
 IN_FREQ_FP = os.path.join(PR_OUT_DIR, "team_event_frequency.csv")
 IN_SESS_FP = os.path.join(PR_OUT_DIR, "team_transition_sessions_count.csv")
 IN_CLUSTER_FP = os.path.join(PR_OUT_DIR, f"behavior_clusters_{FOLDER_SOURCE}.csv")
+IN_ZFILT_FP = os.path.join(PR_OUT_DIR, f"team_transition_edges_avg_session_zfiltered_{FOLDER_SOURCE}.csv")
 
 OUT_TEAMS_DIR = PR_OUT_DIR
 OUT_CLUSTERS_DIR = os.path.join(PR_OUT_DIR, "clusters")
 
 
 # ---------- Tiny utils ----------
+def _wrap_team_list(teams: list[str], max_line_len: int = 70, max_teams: int = 40) -> str:
+    teams = [str(t) for t in teams]
+    n = len(teams)
+
+    if n > max_teams:
+        shown = teams[:max_teams]
+        suffix = f", … (+{n - max_teams} more)"
+    else:
+        shown = teams
+        suffix = ""
+
+    prefix = f"Teams (n={n}): "
+    lines = []
+    cur = prefix
+    for t in shown:
+        piece = ("" if cur.endswith(": ") else ", ") + t
+        if len(cur) + len(piece) > max_line_len and cur != prefix:
+            lines.append(cur)
+            cur = " " * len(prefix) + t
+        else:
+            cur += piece
+    lines.append(cur + suffix)
+    return "\n".join(lines)
+
+
 def ensure_dir(path: str):
     os.makedirs(path, exist_ok=True)
 
@@ -115,7 +141,9 @@ def load_sessions_count_map(sess_fp: str) -> dict:
 
 
 # ---------- Rendering (same styling as old script) ----------
-def build_markov_graph(user_label, edges_df, event_freq, output_path, title_suffix="", normalize_probs=True):
+def build_markov_graph(user_label, edges_df, event_freq, output_path,
+                       title_suffix="", normalize_probs=True,
+                       teams_in_cluster=None):
     edges_df = edges_df.copy()
     edges_df = edges_df[edges_df["count"] > 0]
     if edges_df.empty:
@@ -183,7 +211,11 @@ def build_markov_graph(user_label, edges_df, event_freq, output_path, title_suff
     title = f"Markov Graph — {user_label}"
     if title_suffix:
         title += f" ({title_suffix})"
+    if teams_in_cluster:
+        title += "\n" + _wrap_team_list(teams_in_cluster)
+
     dot.attr(label=title, labelloc="t", fontsize="14", fontname="Helvetica-Bold")
+
     dot.graph_attr.update(dpi="400")
 
     ensure_dir(os.path.dirname(output_path))
@@ -227,11 +259,13 @@ def render_team_graphs(overall_df: pd.DataFrame, avg_df: pd.DataFrame, freq_map:
 
 
 # ---------- Cluster graphs (optional) ----------
-def _aggregate_cluster_avg_edges(avg_df: pd.DataFrame, teams: list[str], sess_count: dict) -> pd.DataFrame:
+def _aggregate_cluster_edges(edges_df: pd.DataFrame, teams: list[str], sess_count: dict) -> pd.DataFrame:
     """
-    Session-weighted cluster avg edges:
-      cluster_total_counts = sum(team_avg_count * team_num_sessions)
-      cluster_avg = cluster_total_counts / sum(team_num_sessions)
+    Session-weighted aggregation over an edge-list DF with columns:
+      team_number, from, to, count
+
+    cluster_total = sum(team_count * team_sessions)
+    cluster_avg   = cluster_total / sum(team_sessions)
     """
     total_weight = 0
     acc = {}
@@ -239,11 +273,10 @@ def _aggregate_cluster_avg_edges(avg_df: pd.DataFrame, teams: list[str], sess_co
     for t in teams:
         w = int(sess_count.get(t, 0))
         if w <= 0:
-            # fallback: treat as 1 so the team still contributes
             w = 1
         total_weight += w
 
-        sub = avg_df[avg_df["team_number"] == t]
+        sub = edges_df[edges_df["team_number"] == t]
         for _, r in sub.iterrows():
             key = (r["from"], r["to"])
             acc[key] = acc.get(key, 0.0) + float(r["count"]) * w
@@ -263,7 +296,7 @@ def _aggregate_cluster_event_freq(freq_map: dict, teams: list[str]) -> dict:
     return out
 
 
-def render_cluster_graphs(avg_df: pd.DataFrame, freq_map: dict, sess_count: dict):
+def render_cluster_graphs(zfilt_df: pd.DataFrame, freq_map: dict, sess_count: dict):
     if not os.path.exists(IN_CLUSTER_FP):
         print(f"[INFO] No cluster CSV found at {IN_CLUSTER_FP} — skipping cluster graphs.")
         return
@@ -283,7 +316,7 @@ def render_cluster_graphs(avg_df: pd.DataFrame, freq_map: dict, sess_count: dict
     for cluster_id, g in cdf.groupby("cluster_id"):
         teams = sorted(g["team_number"].tolist(), key=lambda x: int(x) if x.isdigit() else 999999)
 
-        cluster_edges = _aggregate_cluster_avg_edges(avg_df, teams, sess_count)
+        cluster_edges = _aggregate_cluster_edges(zfilt_df, teams, sess_count)
         cluster_freq = _aggregate_cluster_event_freq(freq_map, teams)
 
         # match old naming style: cluster1, cluster2, ...
@@ -296,8 +329,10 @@ def render_cluster_graphs(avg_df: pd.DataFrame, freq_map: dict, sess_count: dict
             edges_df=cluster_edges,
             event_freq=cluster_freq,
             output_path=os.path.join(cdir, "cluster_avg_session.png"),
-            title_suffix=f"Avg Session • {CATEGORY_LABEL}",
+            title_suffix=f"Z-filtered Avg Session • {CATEGORY_LABEL}",
+            teams_in_cluster=teams,
         )
+
 
 
 def main():
@@ -312,6 +347,26 @@ def main():
 
     overall_df = pd.read_csv(IN_OVERALL_FP, low_memory=False)
     avg_df = pd.read_csv(IN_AVG_FP, low_memory=False)
+    
+    if not os.path.exists(IN_ZFILT_FP):
+        raise FileNotFoundError(
+            f"Missing required input: {IN_ZFILT_FP}\n"
+            f"Run clustering.py first to generate the z-filtered edges export."
+        )
+
+    zfilt_df = pd.read_csv(IN_ZFILT_FP, low_memory=False)
+
+    # normalize like the others
+    required = {"team_number", "from", "to", "count"}
+    missing = required - set(zfilt_df.columns)
+    if missing:
+        raise ValueError(f"Missing columns in z-filtered edges CSV: {missing}")
+
+    zfilt_df["team_number"] = zfilt_df["team_number"].apply(_as_str_team)
+    zfilt_df["from"] = zfilt_df["from"].astype(str)
+    zfilt_df["to"] = zfilt_df["to"].astype(str)
+    zfilt_df["count"] = pd.to_numeric(zfilt_df["count"], errors="coerce").fillna(0.0).astype(float)
+
 
     # normalize team_number to string
     for df in [overall_df, avg_df]:
@@ -328,7 +383,8 @@ def main():
     sess_count = load_sessions_count_map(IN_SESS_FP)
 
     render_team_graphs(overall_df, avg_df, freq_map)
-    render_cluster_graphs(avg_df, freq_map, sess_count)
+    render_cluster_graphs(zfilt_df, freq_map, sess_count)
+
 
     print(f"\n[✅ DONE] Graphs written under: {PR_OUT_DIR}")
 

--- a/test/test_clustering_filtered_edges_export.py
+++ b/test/test_clustering_filtered_edges_export.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+def _load_clustering_module():
+    repo_root = Path(__file__).resolve().parents[1]
+
+    path = repo_root / "process_model" / "clustering.py"
+
+    if path.exists():
+        spec = importlib.util.spec_from_file_location("clustering_under_test", path)
+        assert spec and spec.loader, f"Failed to load spec for {path}"
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+        return mod
+
+    raise FileNotFoundError(
+        "Could not locate clustering.py. Add its path to CANDIDATE_PATHS in the test."
+    )
+
+
+@pytest.fixture()
+def clustering_mod():
+    return _load_clustering_module()
+
+
+def _write_input_csv(tmp_path: Path) -> Path:
+    df = pd.DataFrame(
+        [
+            {"team_number": 1, "from": "START", "to": "A", "count": 0.9, "z_score": 2.0},
+            {"team_number": 1, "from": "A", "to": "END", "count": 0.1, "z_score": 0.5},
+            {"team_number": 2, "from": "START", "to": "A", "count": 0.7, "z_score": -2.2},
+            {"team_number": 2, "from": "A", "to": "END", "count": 0.3, "z_score": -1.7},
+            {"team_number": 3, "from": "START", "to": "A", "count": 0.6, "z_score": 0.1},
+            {"team_number": 3, "from": "A", "to": "END", "count": 0.4, "z_score": 0.2},
+        ]
+    )
+
+    fp = tmp_path / "team_transition_edges_avg_session_zscores.csv"
+    df.to_csv(fp, index=False)
+    return fp
+
+
+def test_filtered_edges_csv_export(tmp_path: Path, clustering_mod, monkeypatch):
+    in_fp = _write_input_csv(tmp_path)
+
+    out_clusters = tmp_path / "behavior_clusters_test.csv"
+    out_matrix = tmp_path / "team_transition_matrix_test.csv"
+    out_edges = tmp_path / "team_transition_edges_avg_session_zfiltered_test.csv"
+
+    monkeypatch.setattr(clustering_mod, "IN_FP", str(in_fp))
+    monkeypatch.setattr(clustering_mod, "OUT_FP", str(out_clusters))
+    monkeypatch.setattr(clustering_mod, "MATRIX_OUT_FP", str(out_matrix))
+    monkeypatch.setattr(clustering_mod, "FILTERED_EDGES_OUT_FP", str(out_edges))
+    monkeypatch.setattr(clustering_mod, "Z_THRESHOLD", 1.645)
+
+    clustering_mod.main()
+
+    # ---- filtered edges export exists
+    assert out_edges.exists(), "Filtered edges CSV was not created"
+
+    edges = pd.read_csv(out_edges)
+
+    # required columns
+    assert {"team_number", "from", "to", "count", "z_score"}.issubset(edges.columns)
+
+    # both tails condition holds
+    assert (edges["z_score"].abs() >= clustering_mod.Z_THRESHOLD).all()
+
+    # dropped team 3 should not be present
+    assert set(edges["team_number"].astype(str).unique()) == {"1", "2"}
+
+    # sanity: should only include the 3 surviving edges
+    # (team1 START->A; team2 START->A; team2 A->END)
+    assert len(edges) == 3

--- a/test/test_clustering_matrix_export.py
+++ b/test/test_clustering_matrix_export.py
@@ -4,27 +4,12 @@ import importlib.util
 from pathlib import Path
 
 import pandas as pd
+from test.test_clustering_filtered_edges_export import clustering_mod
 import pytest
-
-@pytest.fixture()
-def clustering_mod():
-    repo_root = Path(__file__).resolve().parents[1]
-
-    path = repo_root / "process_model" / "clustering.py"
-
-    if path.exists():
-        spec = importlib.util.spec_from_file_location("clustering_under_test", path)
-        assert spec and spec.loader, f"Failed to load spec for {path}"
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)  # type: ignore[attr-defined]
-        return mod
-
-    raise FileNotFoundError(
-        "Could not locate clustering.py. Add its path to CANDIDATE_PATHS in the test."
-    )
 
 
 def _write_input_csv(tmp_path: Path) -> Path:
+    # includes both tails + one team that will be dropped
     df = pd.DataFrame(
         [
             {"team_number": 1, "from": "START", "to": "A", "count": 0.9, "z_score": 2.0},
@@ -41,7 +26,7 @@ def _write_input_csv(tmp_path: Path) -> Path:
     return fp
 
 
-def test_filtered_edges_csv_export(tmp_path: Path, clustering_mod, monkeypatch):
+def test_transition_matrix_csv_export(tmp_path: Path, clustering_mod, monkeypatch):
     in_fp = _write_input_csv(tmp_path)
 
     out_clusters = tmp_path / "behavior_clusters_test.csv"
@@ -53,22 +38,25 @@ def test_filtered_edges_csv_export(tmp_path: Path, clustering_mod, monkeypatch):
     monkeypatch.setattr(clustering_mod, "MATRIX_OUT_FP", str(out_matrix))
     monkeypatch.setattr(clustering_mod, "FILTERED_EDGES_OUT_FP", str(out_edges))
     monkeypatch.setattr(clustering_mod, "Z_THRESHOLD", 1.645)
+
     clustering_mod.main()
 
-    # ---- filtered edges export exists
-    assert out_edges.exists(), "Filtered edges CSV was not created"
+    # ---- matrix export exists
+    assert out_matrix.exists(), "Transition matrix CSV was not created"
 
-    edges = pd.read_csv(out_edges)
-
-    # required columns
-    assert {"team_number", "from", "to", "count", "z_score"}.issubset(edges.columns)
-
-    # both tails condition holds
-    assert (edges["z_score"].abs() >= clustering_mod.Z_THRESHOLD).all()
+    mat = pd.read_csv(out_matrix)
+    assert "team_number" in mat.columns, "Matrix CSV should include team_number column"
 
     # dropped team 3 should not be present
-    assert set(edges["team_number"].astype(str).unique()) == {"1", "2"}
+    assert set(mat["team_number"].astype(str).tolist()) == {"1", "2"}
 
-    # sanity: should only include the 3 surviving edges
-    # (team1 START->A; team2 START->A; team2 A->END)
-    assert len(edges) == 3
+    # columns from FULL df pairs should exist
+    assert "START->A" in mat.columns
+    assert "A->END" in mat.columns
+
+    # values match surviving edges; filtered-out edges remain 0
+    mat = mat.set_index("team_number")
+    assert pytest.approx(mat.loc[1, "START->A"], rel=1e-9) == 0.9
+    assert pytest.approx(mat.loc[1, "A->END"], rel=1e-9) == 0.0  # filtered out
+    assert pytest.approx(mat.loc[2, "START->A"], rel=1e-9) == 0.7
+    assert pytest.approx(mat.loc[2, "A->END"], rel=1e-9) == 0.3


### PR DESCRIPTION
This PR fixes and extends the behavior clustering + visualization pipeline by (1) switching z-score thresholding from a one-sided filter (`z ≥ cutoff`) to a proper two-tailed filter (`|z| ≥ cutoff`) so both unusually high and unusually low transitions are retained, (2) exporting the per-team transition **matrix** used for clustering as a CSV for easier inspection/debugging, (3) exporting a CSV of the **z-filtered transition edges** that actually survive the cutoff (aligned with the feature matrix), and (4) updating cluster graph generation to aggregate and render **z-filtered** edges (instead of the unfiltered avg-session edges) so cluster Markov graphs now reflect the same signal used by KMeans rather than the full transition distribution.

### Test Scripts
Two pytest scripts were added to validate the new CSV exports end-to-end (by running `clustering.main()` against a tiny synthetic input CSV):

* `test/test_clustering_matrix_export.py` — asserts the **transition matrix CSV** is created, includes the expected `from->to` columns, excludes dropped all-zero teams, and that surviving edge counts land in the correct cells (with filtered-out edges staying 0).
* `test/test_clustering_filtered_edges_export.py` — asserts the **z-filtered edges CSV** is created, contains the required columns, only includes rows where `|z_score| >= Z_THRESHOLD` (both tails), and excludes teams that were dropped during matrix build.


### Testing
Pytest
[x]`pytest test/test_clustering_matrix_export.py`
[x]`pytest test/test_clustering_filtered_edges_export.py`

Manual
[x] run all the instructions in README until transition_edges.py
[x] run `python -m process_model.clustering` and verify the exported matrix and filtered zscore csvs (two new files)
[x] run `python -m process_model.graphing` to see fixes in the cluster graphs

Closes: #33, #35, and #58